### PR TITLE
Zachování původního state objektu

### DIFF
--- a/client-side/history.ajax.js
+++ b/client-side/history.ajax.js
@@ -62,12 +62,16 @@
 				}
 			}, this));
 
-			history.replaceState(this.initialState = {
-				nette: true,
-				href: window.location.href,
-				title: document.title,
-				ui: this.cache ? findSnippets() : null
-			}, document.title, window.location.href);
+			this.initialState = $.extend({},
+				history.state || {},
+				{
+					nette: true,
+					href: window.location.href,
+					title: document.title,
+					ui: this.cache ? findSnippets() : null
+				});
+
+			history.replaceState(this.initialState, document.title, window.location.href);
 		},
 		before: function (xhr, settings) {
 			if (!settings.nette) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "history.nette.ajax.js",
 	"title": "history.nette.ajax.js",
 	"description": "Adds History API support for Nette Framework.",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"author": "Vojtech Dobes <me@vojtechdobes.com>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>"


### PR DESCRIPTION
Při volání `replaceState` nenahrazujeme za kompletně vlastní stav, ale zachováváme původní objekt, pokud nějaký byl.