### PR TITLE
jQuery 4 compatibility: replace $.proxy() with .bind()

### DIFF
--- a/client-side/history.ajax.js
+++ b/client-side/history.ajax.js
@@ -44,7 +44,7 @@
 			this.popped = !!('state' in window.history) && !!window.history.state;
 			var initialUrl = window.location.href;
 
-			$(window).on('popstate.nette', $.proxy(function (e) {
+			$(window).on('popstate.nette', (function (e) {
 				var state = e.originalEvent.state || this.initialState;
 				var initialPop = (!this.popped && initialUrl === state.href);
 				this.popped = true;
@@ -60,7 +60,7 @@
 						off: ['history']
 					});
 				}
-			}, this));
+			}).bind(this));
 
 			this.initialState = $.extend({},
 				history.state || {},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "history.nette.ajax.js",
 	"title": "history.nette.ajax.js",
 	"description": "Adds History API support for Nette Framework.",
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"author": "Vojtech Dobes <me@vojtechdobes.com>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>"


### PR DESCRIPTION
`$.proxy()` was removed in jQuery 4. Replace with native `Function.prototype.bind()`, which is backward compatible with jQuery 3.

Bump version to 1.1.0.